### PR TITLE
feat/add promocode feature from subscription and onetime payment

### DIFF
--- a/components/paymentIntent/paymentIntent.controller.js
+++ b/components/paymentIntent/paymentIntent.controller.js
@@ -6,6 +6,7 @@ class PaymentIntentController {
     try {
       const result = await paymentIntentService.createPaymentIntent(
         req.body.priceId,
+        req.body.promocodeId,
         req.user.stripeCustomerId
       );
       res.status(201).json(result);

--- a/components/paymentIntent/paymentIntent.route.js
+++ b/components/paymentIntent/paymentIntent.route.js
@@ -2,18 +2,21 @@ const express = require("express");
 const validate = require("../../middleware/validation");
 const paymentIntentController = require("./paymentIntent.controller");
 const authMiddleware = require("../../middleware/authMiddleware");
+const paymentIntentValidation = require("./paymentIntent.validation");
 
 const router = express.Router();
 
 router.post(
   "/",
   authMiddleware.isUserLoggedIn,
+  validate(paymentIntentValidation.createPaymentIntent),
   paymentIntentController.createPaymentIntent
 );
 
 router.post(
   "/confirm",
   authMiddleware.isUserLoggedIn,
+  validate(paymentIntentValidation.confirmPaymentIntent),
   paymentIntentController.confirmPaymentIntent
 );
 

--- a/components/paymentIntent/paymentIntent.service.js
+++ b/components/paymentIntent/paymentIntent.service.js
@@ -1,11 +1,14 @@
+const { Op } = require("sequelize");
 const common = require("../../constants/common");
 const paymentDb = require("../../dbUtils/paymentDb");
+const promocodeDb = require("../../dbUtils/promocodeDb");
 const userDb = require("../../dbUtils/userDb");
 const stripeHelper = require("../../utils/stripeHelper");
 const _ = require("lodash");
+const helper = require("../../utils/helper");
 
 class PaymentIntentService {
-  async createPaymentIntent(priceId, customerId) {
+  async createPaymentIntent(priceId, promocodeId, customerId) {
     try {
       const priceFound = await stripeHelper.findPriceByStripePriceId(priceId);
       if (!priceFound.active) {
@@ -14,15 +17,38 @@ class PaymentIntentService {
       if (priceFound.type == "recurring") {
         throw new Error("INVALID_PRICE");
       }
+
+      let totalAmount = priceFound.unit_amount / 100;
+
+      if (promocodeId) {
+        const checkPromocodeIsValid = await helper.checkPromocodeIsValid(
+          promocodeId,
+          priceFound.unit_amount,
+          priceFound.currency
+        );
+
+        if (checkPromocodeIsValid.amount_off) {
+          totalAmount -= checkPromocodeIsValid.amount_off;
+        }
+
+        if (checkPromocodeIsValid.percent_off) {
+          totalAmount -=
+            (totalAmount * checkPromocodeIsValid.percent_off) / 100;
+        }
+        totalAmount = Math.max(0, totalAmount);
+      }
       const paymentIntent = await stripeHelper.createPaymentIntent(
-        priceFound.unit_amount / 100,
+        totalAmount,
         priceFound.currency,
         priceId,
         customerId
       );
+      if (!paymentIntent) throw new Error("PAYMENT_INTENT_NOT_CREATED");
       const userFound = await userDb.findUserByStripeCustomerId(
         paymentIntent.customer
       );
+      if (!userFound) throw new Error("USER_NOT_FOUND");
+
       await paymentDb.addPaymentDataInDb({
         stripeCustomerId: paymentIntent.customer,
         userId: userFound.id,
@@ -38,13 +64,13 @@ class PaymentIntentService {
       return {
         id: paymentIntent.id,
         clientSecret: paymentIntent.client_secret,
-        // paymentIntent,
       };
     } catch (err) {
       console.log(`Error from create payment intent`, err);
       throw new Error(err.message);
     }
   }
+
   async confirmPaymentIntent(
     paymentIntentId,
     paymentMethodId,
@@ -61,6 +87,7 @@ class PaymentIntentService {
         paymentIntentId,
         paymentMethodId
       );
+      if (!result) throw new Error("PAYMENT_INTENT_NOT_CONFIRMED");
       await paymentDb.updatePaymentDataInDb(
         {
           paymentMethod: {

--- a/components/paymentIntent/paymentIntent.validation.js
+++ b/components/paymentIntent/paymentIntent.validation.js
@@ -1,0 +1,16 @@
+const Joi = require("joi");
+
+module.exports = {
+  createPaymentIntent: {
+    body: Joi.object({
+      priceId: Joi.string().required(),
+      promocodeId: Joi.string().optional(),
+    }),
+  },
+  confirmPaymentIntent: {
+    body: Joi.object({
+      paymentIntentId: Joi.string().required(),
+      paymentMethodId: Joi.string().required(),
+    }),
+  },
+};

--- a/components/paymentMethod/paymentMethod.service.js
+++ b/components/paymentMethod/paymentMethod.service.js
@@ -10,6 +10,7 @@ class PaymentMethodService {
         billingDetails,
         customerId
       );
+      if (!paymentMethod) throw new Error("PAYMENT_METHOD_NOT_CREATED");
       const checkDefaultMethodExist = await userDb.checkDefaultMethodExist(
         customerId
       );
@@ -42,17 +43,15 @@ class PaymentMethodService {
   }
   async updatePaymentMethod(paymentMethodId, paymentDetails, billingDetails) {
     try {
-      await stripeHelper.updatePaymentMethod(
+      const updatedMethod = await stripeHelper.updatePaymentMethod(
         paymentMethodId,
         paymentDetails,
         billingDetails
       );
+      if (!updatedMethod) throw new Error("PAYMENT_METHOD_NOT_UPDATED");
       return { status: true };
     } catch (err) {
       console.log({ "Error from update payment method": err });
-      // if (err.type.includes("Stripe")) {
-      //   stripeHelper.throwStripeErrors(err);
-      // }
       throw new Error(err.message);
     }
   }
@@ -82,9 +81,6 @@ class PaymentMethodService {
       return { paymentMethods: paymentMethods.data };
     } catch (err) {
       console.log({ "Error from get all payment method": err });
-      // if (err.type.includes("Stripe")) {
-      //   stripeHelper.throwStripeErrors(err);
-      // }
       throw new Error(err.message);
     }
   }
@@ -110,9 +106,6 @@ class PaymentMethodService {
       };
     } catch (err) {
       console.log({ "Error from setting default payment method": err });
-      // if (err.type.includes("Stripe")) {
-      //   stripeHelper.throwStripeErrors(err);
-      // }
       throw new Error(err.message);
     }
   }
@@ -144,9 +137,6 @@ class PaymentMethodService {
       };
     } catch (err) {
       console.log({ "Error from delete payment method": err });
-      // if (err.type.includes("Stripe")) {
-      //   await stripeHelper.throwStripeErrors(err);
-      // }
       throw new Error(err.message);
     }
   }

--- a/components/promocode/promocode.controller.js
+++ b/components/promocode/promocode.controller.js
@@ -1,0 +1,54 @@
+const promocodeService = require("./promocode.service");
+
+promocodeService;
+class PromocodeController {
+  async createPromocode(req, res, next) {
+    try {
+      const code = await promocodeService.createPromocode(
+        req.body,
+        req.user.id
+      );
+      res.status(201).json(code);
+    } catch (err) {
+      next(err);
+    }
+  }
+  async updatePromocode(req, res, next) {
+    try {
+      const code = await promocodeService.updatePromocode(
+        req.body.stripePromoCodeId,
+        req.body,
+        req.user.id
+      );
+      res.status(201).json(code);
+    } catch (err) {
+      next(err);
+    }
+  }
+  async deletePromocode(req, res, next) {
+    try {
+      const result = await promocodeService.deletePromocode(
+        req.body.stripePromoCodeId,
+        req.user.id
+      );
+      res.status(200).json(result);
+    } catch (err) {
+      next(err);
+    }
+  }
+  async getAllActivePromocode(req, res, next) {
+    try {
+      const codes = await promocodeService.getAllActivePromocode(
+        req.body.amount,
+        req.body.currency,
+        req.body.page,
+        req.body.limit
+      );
+      res.status(200).json(codes);
+    } catch (err) {
+      next(err);
+    }
+  }
+}
+
+module.exports = new PromocodeController();

--- a/components/promocode/promocode.route.js
+++ b/components/promocode/promocode.route.js
@@ -1,0 +1,35 @@
+const express = require("express");
+const validate = require("../../middleware/validation");
+const authMiddleware = require("../../middleware/authMiddleware");
+const promocodeController = require("./promocode.controller");
+const promocodeValidation = require("./promocode.validation");
+
+const router = express.Router();
+
+router.post(
+  "/list",
+  authMiddleware.isUserLoggedIn,
+  validate(promocodeValidation.getAllActivePromocode),
+  promocodeController.getAllActivePromocode
+);
+router.post(
+  "/",
+  authMiddleware.isUserLoggedIn,
+  validate(promocodeValidation.createPromocode),
+  promocodeController.createPromocode
+);
+router.put(
+  "/",
+  authMiddleware.isUserLoggedIn,
+  validate(promocodeValidation.updatePromocode),
+  promocodeController.updatePromocode
+);
+
+router.delete(
+  "/",
+  authMiddleware.isUserLoggedIn,
+  validate(promocodeValidation.deletePromocode),
+  promocodeController.deletePromocode
+);
+
+module.exports = router;

--- a/components/promocode/promocode.service.js
+++ b/components/promocode/promocode.service.js
@@ -1,0 +1,134 @@
+const { Op, Sequelize } = require("sequelize");
+const promocodeDb = require("../../dbUtils/promocodeDb");
+const helper = require("../../utils/helper");
+const stripeHelper = require("../../utils/stripeHelper");
+
+class PromocodeService {
+  async createPromocode(promoCodeData, loggedInUserId) {
+    try {
+      const isPromocodeExist = await promocodeDb.findPromocodeByFilter(
+        { code: promoCodeData.code },
+        ["isActive"]
+      );
+      if (isPromocodeExist && isPromocodeExist.isActive != "false") {
+        throw new Error("Promo code already exist");
+      }
+      promoCodeData.expires_at = await helper.convertDateToTimestamp(
+        promoCodeData.expires_at
+      );
+      const coupon = await stripeHelper.createCoupen(promoCodeData);
+      const promocode = await stripeHelper.createPromocode(
+        promoCodeData,
+        coupon.id
+      );
+      const result = await promocodeDb.addPromocodeInDb(
+        promocode,
+        loggedInUserId
+      );
+      return { promocode: result };
+    } catch (err) {
+      throw new Error(err.message);
+    }
+  }
+
+  async deletePromocode(promocodeId, loggedInUserId) {
+    try {
+      const promocodeData = await promocodeDb.findPromocodeByFilter(
+        { stripePromoCodeId: promocodeId, isActive: { [Op.eq]: "true" } },
+        ["isActive", "stripeCouponId"]
+      );
+      if (!promocodeData || promocodeData.isActive == "false") {
+        throw new Error("CODE_ALREADY_DELETED");
+      }
+
+      await stripeHelper.deleteCoupon(promocodeData.stripeCouponId);
+      await stripeHelper.deletePromoCode(promocodeId);
+      await promocodeDb.deletePromocodeInDb(
+        { stripeCouponId: promocodeData.stripeCouponId },
+        loggedInUserId
+      );
+      return { message: "deleted successfully" };
+    } catch (err) {
+      throw new Error(err.message);
+    }
+  }
+
+  async updatePromocode(promocodeId, updateData, loggedInUserId) {
+    try {
+      const promocodeData = await promocodeDb.findPromocodeByFilter(
+        { stripePromoCodeId: promocodeId, isActive: { [Op.eq]: "true" } },
+        ["isActive", "stripeCouponId", "code"]
+      );
+      if (
+        !promocodeData ||
+        (promocodeData.isActive == "false" && !promocodeData.deletedBy)
+      ) {
+        throw new Error("CODE_ALREADY_DELETED");
+      }
+      const checkPromocodeExistWithName =
+        await promocodeDb.countPromocodeByQuery({
+          where: {
+            [Op.and]: [
+              { code: { [Op.iLike]: updateData.name } },
+              { stripePromoCodeId: { [Op.ne]: promocodeId } },
+            ],
+          },
+        });
+      if (checkPromocodeExistWithName > 0) {
+        throw new Error("CODE_ALREADY_EXIST");
+      }
+      const updatedCoupon = await stripeHelper.updateCoupon(
+        promocodeData.stripeCouponId,
+        {
+          name: updateData.name,
+        }
+      );
+
+      const result = await promocodeDb.updatePromocodeInDb(
+        { stripePromoCodeId: promocodeId },
+        {
+          stripeCouponId: updatedCoupon.id,
+          updatedBy: loggedInUserId,
+        }
+      );
+      return { updatedPromocode: result };
+    } catch (err) {
+      throw new Error(err.message);
+    }
+  }
+
+  async getAllActivePromocode(amount, currency, page, limit) {
+    try {
+      const allPromocode = await promocodeDb.findAllPromocodeFromDb(
+        {
+          [Op.and]: [
+            {
+              [Op.or]: [
+                { minimum_amount: { [Op.lte]: amount } },
+                { minimum_amount: { [Op.is]: null } },
+              ],
+            },
+            {
+              [Op.or]: [
+                { minimum_amount_currency: { [Op.eq]: currency } },
+                { minimum_amount_currency: { [Op.is]: null } },
+              ],
+            },
+            Sequelize.where(
+              Sequelize.literal("max_redemptions - times_redeemed"),
+              { [Op.gt]: 0 }
+            ),
+          ],
+        },
+        page,
+        limit,
+        { exclude: ["createdBy", "updatedBy", "deletedBy"] }
+      );
+      return { allPromocode };
+    } catch (err) {
+      throw new Error(err.message);
+    }
+  }
+}
+
+module.exports = new PromocodeService();

--- a/components/promocode/promocode.validation.js
+++ b/components/promocode/promocode.validation.js
@@ -1,0 +1,38 @@
+const Joi = require("joi");
+
+module.exports = {
+  createPromocode: {
+    body: Joi.object({
+      code: Joi.string().required(),
+      currency: Joi.string().required(),
+      durationType: Joi.string().required(),
+      duration_in_months: Joi.number().default(6),
+      name: Joi.string().required(),
+      max_redemptions: Joi.number(),
+      percent_off: Joi.number(),
+      amount_off: Joi.number(),
+      minimum_amount: Joi.number(),
+      minimum_amount_currency: Joi.string(),
+      expires_at: Joi.string(),
+    }),
+  },
+  updatePromocode: {
+    body: Joi.object({
+      stripePromoCodeId: Joi.string().required(),
+      name: Joi.string().required(),
+    }),
+  },
+  deletePromocode: {
+    body: Joi.object({
+      stripePromoCodeId: Joi.string().required(),
+    }),
+  },
+  getAllActivePromocode: {
+    body: Joi.object({
+      amount: Joi.number().required(),
+      currency: Joi.string().required(),
+      page: Joi.number().default(1).min(1).required(),
+      limit: Joi.number().min(10).default(15).required(),
+    }),
+  },
+};

--- a/components/purchase/purchase.service.js
+++ b/components/purchase/purchase.service.js
@@ -1,5 +1,6 @@
 const common = require("../../constants/common");
 const paymentDb = require("../../dbUtils/paymentDb");
+const helper = require("../../utils/helper");
 const stripeHelper = require("../../utils/stripeHelper");
 
 class PurchaseService {
@@ -54,6 +55,7 @@ class PurchaseService {
       throw new Error(err.message);
     }
   }
+
   async getHistoryOfUserPurchase(customerId) {
     try {
       const history = await paymentDb.purchaseHistoryOfCustomer(customerId, [
@@ -64,68 +66,12 @@ class PurchaseService {
         "subscriptionId",
         "paymentIntentId",
       ]);
-      await Promise.all(
-        history.map(async (record) => {
-          if (record.invoiceId !== null && record.subscriptionId !== null) {
-            const subscription =
-              await stripeHelper.getSubscriptionBySubscriptionId(
-                record.subscriptionId
-              );
-            const invoice = await stripeHelper.getInvoiceById(record.invoiceId);
 
-            const startDate = new Date(invoice.created * 1000);
-
-            let endDate = new Date(startDate);
-
-            const unit = subscription.plan.interval;
-            const value = subscription.plan.interval_count;
-
-            switch (unit.toLowerCase()) {
-              case "week":
-                endDate.setDate(endDate.getDate() + value * 7);
-                break;
-              case "month":
-                endDate.setMonth(endDate.getMonth() + value);
-                break;
-              case "year":
-                endDate.setFullYear(endDate.getFullYear() + value);
-                break;
-              default:
-                endDate.setDate(endDate.getDate() + 30);
-                break;
-            }
-
-            record.planName = subscription.metadata.planName;
-            record.amount = invoice.amount_due / 100;
-            record.currency = subscription.currency.toUpperCase();
-            record.status = subscription.status;
-            record.startDate = startDate.toISOString();
-            record.nextDueDate = endDate.toISOString();
-            record.planEndDate = subscription.cancel_at
-              ? new Date(subscription.cancel_at * 1000).toISOString()
-              : new Date(subscription.canceled_at * 1000).toISOString();
-            record.invoiceUrl = invoice.hosted_invoice_url;
-          } else {
-            const paymentIntent = await stripeHelper.getPaymentIntentById(
-              record.paymentIntentId
-            );
-            record.planName =
-              paymentIntent.metadata.planName || "One-time purchase";
-            record.amount = paymentIntent.amount / 100;
-            record.currency = paymentIntent.currency.toUpperCase();
-            record.startDate = new Date(
-              paymentIntent.created * 1000
-            ).toISOString();
-            record.nextDueDate = null;
-            record.planEndDate = new Date(
-              paymentIntent.metadata.planEndDate
-            ).toISOString();
-          }
-        })
-      );
+      await helper.formatTransactionData(history);
       if (history.length < 1) {
         throw new Error("PLAN_NOT_FOUND");
       }
+
       return { history };
     } catch (err) {
       throw new Error(err.message);

--- a/components/subscription/subscription.controller.js
+++ b/components/subscription/subscription.controller.js
@@ -6,7 +6,8 @@ class SubscriptionController {
       const subscription = await subcriptionService.createSubscription(
         req.user.stripeCustomerId,
         req.body.priceId,
-        req.body.paymentMethodId
+        req.body.paymentMethodId,
+        req.body.promocode
       );
       res.status(200).json(subscription);
     } catch (err) {

--- a/components/subscription/subscription.service.js
+++ b/components/subscription/subscription.service.js
@@ -1,10 +1,17 @@
 const common = require("../../constants/common");
 const paymentDb = require("../../dbUtils/paymentDb");
+const promocodeDb = require("../../dbUtils/promocodeDb");
 const userDb = require("../../dbUtils/userDb");
+const helper = require("../../utils/helper");
 const stripeHelper = require("../../utils/stripeHelper");
 
 class SubscriptionService {
-  async createSubscription(stripeCustomerId, priceId, paymentMethodId) {
+  async createSubscription(
+    stripeCustomerId,
+    priceId,
+    paymentMethodId,
+    promocode
+  ) {
     try {
       const customerFound = await stripeHelper.findCustomerByCustomerId(
         stripeCustomerId
@@ -22,22 +29,34 @@ class SubscriptionService {
       if (paymentMethodExist.customer != customerFound.id) {
         throw new Error("PAYMENT_METHOD_NOT_ATTACHED");
       }
+
+      const checkPromocodeIsValid = await helper.checkPromocodeIsValid(
+        promocode,
+        priceDetails.unit_amount,
+        priceDetails.currency
+      );
+
       const subscription = await stripeHelper.createSubscription(
         stripeCustomerId,
         priceId,
-        paymentMethodId
+        paymentMethodId,
+        checkPromocodeIsValid.stripePromoCodeId
       );
 
       const userFound = await userDb.findUserByStripeCustomerId(
         subscription.customer
       );
-      await paymentDb.addPaymentDataInDb({
+
+      const newTransaction = {
         stripeCustomerId: subscription.customer,
         userId: userFound.id,
-        amount: subscription.latest_invoice.amount_due / 100,
+        amount: subscription.latest_invoice.subtotal / 100,
         currency: subscription.currency,
         paymentType: common.PAYMENT_TYPE.SUBSCRIPTION,
-        paymentStatus: common.PAYMENT_STATUS.PENDING,
+        paymentStatus:
+          subscription.latest_invoice.amount_due === 0
+            ? common.PAYMENT_STATUS.SUCCEEDED
+            : common.PAYMENT_STATUS.PENDING,
         paymentMethod: {
           id: subscription.default_payment_method,
           type: "card",
@@ -45,7 +64,9 @@ class SubscriptionService {
         invoiceId: subscription.latest_invoice.id,
         subscriptionId: subscription.id,
         paymentIntentId: null,
-      });
+      };
+      await paymentDb.addPaymentDataInDb(newTransaction);
+
       return subscription;
     } catch (err) {
       console.log({ "Error from create subscription": err });

--- a/components/subscription/subscription.validation.js
+++ b/components/subscription/subscription.validation.js
@@ -5,6 +5,7 @@ module.exports = {
     body: Joi.object({
       priceId: Joi.string().required(),
       paymentMethodId: Joi.string().required(),
+      promocode: Joi.string(),
     }),
   },
   updateSubscription: {

--- a/components/webhook/webhook.service.js
+++ b/components/webhook/webhook.service.js
@@ -3,6 +3,7 @@ const webhookHelper = require("../../utils/webhookHelper");
 const queueHelper = require("../../utils/queueHelper");
 
 const _ = require("lodash");
+const promocodeDb = require("../../dbUtils/promocodeDb");
 
 class WebhookService {
   async stripeWebhooks(body, sig) {
@@ -12,7 +13,7 @@ class WebhookService {
 
       if (!event) return;
 
-      let intentObj, subscriptionObj;
+      let intentObj, subscriptionObj, promocodeObj;
 
       switch (event.type) {
         case "payment_intent.payment_failed":
@@ -35,7 +36,17 @@ class WebhookService {
               invoice_settings.default_payment_method
             );
           }
-
+          break;
+        case "promotion_code.updated":
+          promocodeObj = event.data.object;
+          await promocodeDb.updatePromocodeInDb(
+            {
+              stripePromoCodeId: promocodeObj.id,
+            },
+            {
+              times_redeemed: promocodeObj.times_redeemed,
+            }
+          );
           break;
         default:
           break;

--- a/constants/common.js
+++ b/constants/common.js
@@ -22,6 +22,10 @@ module.exports = {
     AUTOMATIC: "charge_automatically",
     SEND_INVOICE: "send_invoice",
   },
+  COLLECTION_BEHAVIOUR: {
+    UNCOLLECTIBLE: "mark_uncollectible",
+    DRAFT: "keep_as_draft",
+  },
   PAYMENT_STATUS: {
     PENDING: "pending",
     PAID: "paid",

--- a/constants/errorCodes.js
+++ b/constants/errorCodes.js
@@ -90,6 +90,20 @@ module.exports = {
 
   //payment methods
 
+  PAYMENT_METHOD_NOT_CREATED: {
+    httpStatusCode: 403,
+    body: {
+      code: "failed",
+      message: "Failed to create payment method",
+    },
+  },
+  PAYMENT_METHOD_NOT_UPDATED: {
+    httpStatusCode: 403,
+    body: {
+      code: "failed",
+      message: "Failed to update payment method",
+    },
+  },
   PAYMENT_METHOD_NOT_FOUND: {
     httpStatusCode: 404,
     body: {
@@ -120,6 +134,60 @@ module.exports = {
       code: "invalid",
       message:
         "Ensure that subscription create for recurring price and payment intent for onetime price only not vice versa.",
+    },
+  },
+
+  //Promocode related
+  CODE_ALREADY_DELETED: {
+    httpStatusCode: 404,
+    body: {
+      code: "not_found",
+      message: "Promo code is already deleted.",
+    },
+  },
+  CODE_ALREADY_EXIST: {
+    httpStatusCode: 409,
+    body: {
+      code: "duplicate",
+      message: "Promo code is already exist with this name.",
+    },
+  },
+  CODE_NOT_FOUND: {
+    httpStatusCode: 404,
+    body: {
+      code: "not_found",
+      message: "Invalid promo code.",
+    },
+  },
+  INVALID_CURRENCY: {
+    httpStatusCode: 400,
+    body: {
+      code: "invalid",
+      message: "Promo code is not valid for this currency.",
+    },
+  },
+  MINIMUM_AMOUNT_NOT_MET: {
+    httpStatusCode: 400,
+    body: {
+      code: "invalid",
+      message:
+        "Amount is not match with minimum amount criteria for this promocode.",
+    },
+  },
+
+  //Payment intent related
+  PAYMENT_INTENT_NOT_CREATED: {
+    httpStatusCode: 403,
+    body: {
+      code: "failed",
+      message: "Failed to create payment intent.",
+    },
+  },
+  PAYMENT_INTENT_NOT_CONFIRMED: {
+    httpStatusCode: 403,
+    body: {
+      code: "failed",
+      message: "Failed to confirm payment intent.",
     },
   },
 };

--- a/db/migrations/20250225060758-create-payment.js
+++ b/db/migrations/20250225060758-create-payment.js
@@ -14,6 +14,9 @@ module.exports = {
       },
       userId: {
         type: DataTypes.INTEGER,
+        references: {
+          model: "users",
+        },
       },
       amount: {
         type: DataTypes.INTEGER,

--- a/db/migrations/20250311052428-create-promocode.js
+++ b/db/migrations/20250311052428-create-promocode.js
@@ -1,0 +1,91 @@
+"use strict";
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("promocodes", {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      stripeCouponId: {
+        type: Sequelize.STRING,
+      },
+      stripePromoCodeId: {
+        type: Sequelize.STRING,
+      },
+      code: {
+        type: Sequelize.STRING,
+      },
+      currency: {
+        type: Sequelize.STRING,
+      },
+      duration: {
+        type: Sequelize.ENUM("forever", "once", "repeating"),
+      },
+      duration_in_months: {
+        type: Sequelize.INTEGER,
+      },
+      amount_off: {
+        type: Sequelize.INTEGER,
+      },
+      percent_off: {
+        type: Sequelize.INTEGER,
+      },
+      max_redemptions: {
+        type: Sequelize.INTEGER,
+      },
+      times_redeemed: {
+        type: Sequelize.INTEGER,
+      },
+      minimum_amount: {
+        type: Sequelize.INTEGER,
+      },
+      minimum_amount_currency: {
+        type: Sequelize.STRING,
+      },
+      expiresAt: {
+        type: Sequelize.DATE,
+      },
+      isActive: {
+        type: Sequelize.ENUM("true", "false"),
+        defaultValue: "true",
+      },
+      createdBy: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        references: {
+          model: "users",
+        },
+      },
+      updatedBy: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: "users",
+        },
+        defaultValue: null,
+      },
+      deletedBy: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: "users",
+        },
+        defaultValue: null,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+      },
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable("promocodes");
+  },
+};

--- a/db/models/index.js
+++ b/db/models/index.js
@@ -26,15 +26,25 @@ const RefreshToken = require("./refreshtoken")(sequelize, Sequelize.DataTypes);
 const Plan = require("./plan")(sequelize, Sequelize.DataTypes);
 const Blacklist = require("./blacklist")(sequelize, Sequelize.DataTypes);
 const Payment = require("./payment")(sequelize, Sequelize.DataTypes);
+const Promocode = require("./promocode")(sequelize, Sequelize.DataTypes);
 
 db.User = User;
 db.RefreshToken = RefreshToken;
 db.Plan = Plan;
 db.Blacklist = Blacklist;
 db.Payment = Payment;
+db.Promocode = Promocode;
 
 User.hasMany(Payment, { as: "payments", foreignKey: "userId" });
-Payment.belongsTo(User, { as: "users", foreignKey: "id" });
+Payment.belongsTo(User, { as: "user", foreignKey: "userId" });
+
+User.hasMany(Promocode, {
+  as: "createdPromocodes",
+  foreignKey: "createdBy",
+});
+Promocode.belongsTo(User, { as: "createdByUser", foreignKey: "createdBy" });
+Promocode.belongsTo(User, { as: "updatedByUser", foreignKey: "updatedBy" });
+Promocode.belongsTo(User, { as: "deletedByUser", foreignKey: "deletedBy" });
 
 db.sequelize = sequelize;
 

--- a/db/models/payment.js
+++ b/db/models/payment.js
@@ -24,6 +24,9 @@ module.exports = (sequelize, DataTypes) => {
       },
       userId: {
         type: DataTypes.INTEGER,
+        references: {
+          model: "users",
+        },
       },
       amount: {
         type: DataTypes.INTEGER,

--- a/db/models/promocode.js
+++ b/db/models/promocode.js
@@ -1,0 +1,105 @@
+"use strict";
+const { Model } = require("sequelize");
+module.exports = (sequelize, Sequelize) => {
+  class Promocode extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+    }
+  }
+  Promocode.init(
+    {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      stripeCouponId: {
+        type: Sequelize.STRING,
+      },
+      stripePromoCodeId: {
+        type: Sequelize.STRING,
+      },
+      code: {
+        type: Sequelize.STRING,
+      },
+      currency: {
+        type: Sequelize.STRING,
+      },
+      duration: {
+        type: Sequelize.ENUM("forever", "once", "repeating"),
+      },
+      duration_in_months: {
+        type: Sequelize.INTEGER,
+      },
+      amount_off: {
+        type: Sequelize.INTEGER,
+      },
+      percent_off: {
+        type: Sequelize.INTEGER,
+      },
+      max_redemptions: {
+        type: Sequelize.INTEGER,
+      },
+      times_redeemed: {
+        type: Sequelize.INTEGER,
+      },
+      minimum_amount: {
+        type: Sequelize.INTEGER,
+      },
+      minimum_amount_currency: {
+        type: Sequelize.STRING,
+      },
+      expiresAt: {
+        type: Sequelize.DATE,
+      },
+      isActive: {
+        type: Sequelize.ENUM("true", "false"),
+        defaultValue: "true",
+      },
+      createdBy: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        references: {
+          model: "users",
+        },
+      },
+      updatedBy: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: "users",
+        },
+        defaultValue: null,
+      },
+      deletedBy: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: "users",
+        },
+        defaultValue: null,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+      },
+    },
+    {
+      sequelize,
+      modelName: "Promocode",
+      tableName: "promocodes",
+      timestamps: true,
+    }
+  );
+  return Promocode;
+};

--- a/dbUtils/paymentDb.js
+++ b/dbUtils/paymentDb.js
@@ -4,11 +4,12 @@ const common = require("../constants/common");
 
 class PaymentDb extends Payment {
   async addPaymentDataInDb(paymentData) {
-    await Payment.create(paymentData);
+    const result = await Payment.create(paymentData);
+    return result.toJSON();
   }
 
   async updatePaymentDataInDb(paymentData, id) {
-    await Payment.update(paymentData, {
+    const result = await Payment.update(paymentData, {
       where: {
         [Op.or]: [
           {
@@ -20,7 +21,9 @@ class PaymentDb extends Payment {
         ],
       },
       returning: true,
+      plain: true,
     });
+    return result[1];
   }
 
   async getPaymentStatusFromDb(id) {
@@ -39,7 +42,7 @@ class PaymentDb extends Payment {
     return result.count;
   }
 
-  async purchaseHistoryOfCustomer(customer, attributes) {
+  async purchaseHistoryOfCustomer(customer, attributes = null) {
     const history = await Payment.findAll({
       where: {
         [Op.and]: [

--- a/dbUtils/promocodeDb.js
+++ b/dbUtils/promocodeDb.js
@@ -1,0 +1,88 @@
+const { Promocode, User } = require("../db/models");
+
+class PromocodeDb extends Promocode {
+  async countPromocodeByQuery(query) {
+    const existingPromocde = await Promocode.findAndCountAll(query);
+    return existingPromocde.count;
+  }
+
+  async addPromocodeInDb(promocodeObj, loggedInUserId) {
+    const result = await Promocode.create({
+      stripeCouponId: promocodeObj.coupon.id,
+      stripePromoCodeId: promocodeObj.id,
+      code: promocodeObj.code,
+      currency: promocodeObj.coupon.currency,
+      duration: promocodeObj.coupon.duration,
+      duration_in_months: promocodeObj.coupon.duration_in_months,
+      amount_off: promocodeObj.coupon.amount_off / 100,
+      percent_off: promocodeObj.coupon.percent_off,
+      max_redemptions: promocodeObj.max_redemptions,
+      times_redeemed: promocodeObj.times_redeemed,
+      minimum_amount: promocodeObj.restrictions.minimum_amount || 0,
+      minimum_amount_currency:
+        promocodeObj.restrictions.minimum_amount_currency,
+      expiresAt: new Date(promocodeObj.expires_at * 1000),
+      isActive: promocodeObj.active,
+      createdBy: loggedInUserId,
+      updatedBy: loggedInUserId,
+    });
+    return result;
+  }
+
+  async deletePromocodeInDb(query, loggedInUserId) {
+    await Promocode.update(
+      {
+        isActive: "false",
+        deletedBy: loggedInUserId,
+      },
+      { where: query }
+    );
+  }
+  async updatePromocodeInDb(query, updateObj) {
+    const result = await Promocode.update(updateObj, {
+      where: query,
+      returning: true,
+      plain: true,
+    });
+    return result[1];
+  }
+
+  async findPromocodeByFilter(filter, attributes = null) {
+    return await Promocode.findOne({
+      where: filter,
+      attributes,
+      raw: true,
+    });
+  }
+
+  async findAllPromocodeFromDb(filter, page, limit, attributes = null) {
+    const result = await Promocode.findAll({
+      where: filter,
+      include: [
+        {
+          model: User,
+          as: "createdByUser",
+          attributes: ["name", "email"],
+        },
+        {
+          model: User,
+          as: "updatedByUser",
+          attributes: ["name", "email"],
+        },
+        {
+          model: User,
+          as: "deletedByUser",
+          attributes: ["name", "email"],
+        },
+      ],
+      limit,
+      offset: (page - 1) * limit,
+      raw: true,
+      attributes,
+    });
+
+    return result;
+  }
+}
+module.exports = new PromocodeDb();
+module.exports.PromocodeMdl = Promocode;

--- a/indexRoute.js
+++ b/indexRoute.js
@@ -5,6 +5,7 @@ const paymentMethodRoute = require("./components/paymentMethod/paymentMethod.rou
 const paymentIntentRoute = require("./components/paymentIntent/paymentIntent.route");
 const purchaseRoute = require("./components/purchase/purchase.route");
 const subscriptionRoute = require("./components/subscription/subscription.route");
+const promocodeRoute = require("./components/promocode/promocode.route");
 const router = express.Router();
 
 router.use("/auth", authRoute);
@@ -13,5 +14,6 @@ router.use("/payment-methods", paymentMethodRoute);
 router.use("/onetime", paymentIntentRoute);
 router.use("/purchase", purchaseRoute);
 router.use("/subscriptions", subscriptionRoute);
+router.use("/promocodes", promocodeRoute);
 
 module.exports = router;

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -2,6 +2,8 @@ const jwt = require("jsonwebtoken");
 const config = require("../config/config");
 const { v4: uuidv4 } = require("uuid");
 const refreshTokenDb = require("../dbUtils/refreshTokenDb");
+const stripeHelper = require("./stripeHelper");
+const promocodeDb = require("../dbUtils/promocodeDb");
 
 class Helper {
   async generateAccessAndRefreshToken(userId) {
@@ -25,6 +27,98 @@ class Helper {
       token = authToken.split(" ")[1];
     }
     return token;
+  }
+
+  async convertDateToTimestamp(date) {
+    const timestamp = Date.parse(date) / 1000;
+    return timestamp;
+  }
+
+  async formatTransactionData(history) {
+    return Promise.all(
+      history.map(async (record) => {
+        if (record.invoiceId !== null && record.subscriptionId !== null) {
+          const subscription =
+            await stripeHelper.getSubscriptionBySubscriptionId(
+              record.subscriptionId
+            );
+          const invoice = await stripeHelper.getInvoiceById(record.invoiceId);
+          const startDate = new Date(invoice.created * 1000);
+          let endDate = new Date(startDate);
+
+          const unit = subscription.plan.interval;
+          const value = subscription.plan.interval_count;
+
+          switch (unit.toLowerCase()) {
+            case "week":
+              endDate.setDate(endDate.getDate() + value * 7);
+              break;
+            case "month":
+              endDate.setMonth(endDate.getMonth() + value);
+              break;
+            case "year":
+              endDate.setFullYear(endDate.getFullYear() + value);
+              break;
+            default:
+              endDate.setDate(endDate.getDate() + 30);
+              break;
+          }
+
+          record.planName = subscription.metadata.planName;
+          record.currency = subscription.currency.toUpperCase();
+          record.status = subscription.status;
+          record.startDate = startDate.toISOString();
+          record.nextDueDate = endDate.toISOString();
+          record.planEndDate = subscription.cancel_at
+            ? new Date(subscription.cancel_at * 1000).toISOString()
+            : new Date(subscription.canceled_at * 1000).toISOString();
+          record.invoiceUrl = invoice.hosted_invoice_url;
+        } else {
+          const paymentIntent = await stripeHelper.getPaymentIntentById(
+            record.paymentIntentId
+          );
+
+          record.planName =
+            paymentIntent.metadata.planName || "One-time purchase";
+          record.amount = paymentIntent.amount / 100;
+          record.currency = paymentIntent.currency.toUpperCase();
+          record.startDate = new Date(
+            paymentIntent.created * 1000
+          ).toISOString();
+          record.nextDueDate = null;
+          record.planEndDate = new Date(
+            paymentIntent.metadata.planEndDate
+          ).toISOString();
+          record.receipt_url = paymentIntent.latest_charge.receipt_url;
+        }
+        delete record.stripeCustomerId;
+        delete record.userId;
+        delete record.paymentMethod;
+        return record;
+      })
+    );
+  }
+
+  async checkPromocodeIsValid(promocode, amount, currency) {
+    const promocodeObj = await promocodeDb.findPromocodeByFilter({
+      stripePromoCodeId: promocode,
+    });
+
+    console.log({ promocodeObj });
+
+    if (!promocodeObj) {
+      throw new Error("CODE_NOT_FOUND");
+    }
+
+    if (promocodeObj.currency !== currency) {
+      throw new Error("INVALID_CURRENCY");
+    }
+
+    if (amount < promocodeObj.minimum_amount) {
+      throw new Error("MINIMUM_AMOUNT_NOT_MET");
+    }
+
+    return promocodeObj;
   }
 }
 module.exports = new Helper();

--- a/utils/queueHelper.js
+++ b/utils/queueHelper.js
@@ -34,7 +34,7 @@ class Queues {
     const job = await paymentProcessQueue.add(
       "paymentProcessJob",
       { event },
-      { attempts: 3, removeOnComplete: { age: 10 }, removeOnFail: 5 }
+      { attempts: 5, removeOnComplete: { age: 10 }, removeOnFail: 5 }
     );
     return job;
   }

--- a/utils/stripeHelper.js
+++ b/utils/stripeHelper.js
@@ -24,22 +24,25 @@ module.exports = {
   },
 
   async updatePaymentMethod(paymentMethodId, paymentDetails, billing_details) {
-    await stripe.paymentMethods.update(paymentMethodId, {
+    const paymentMethod = await stripe.paymentMethods.update(paymentMethodId, {
       card: paymentDetails,
       billing_details,
     });
+    return paymentMethod;
   },
 
   async findCustomerByCustomerId(customerId) {
     const customer = await stripe.customers.retrieve(customerId);
     return customer;
   },
+
   //plans related
 
   async findPriceByStripePriceId(priceId) {
     const price = await stripe.prices.retrieve(priceId);
     return price;
   },
+
   async findProductByStripeProductId(productId) {
     const product = await stripe.products.retrieve(productId);
     return product;
@@ -63,6 +66,7 @@ module.exports = {
     });
     return price;
   },
+
   async createRecurringPriceInStripe(data, productId) {
     const price = await stripe.prices.create({
       currency: common.CURRENCY.USD,
@@ -82,11 +86,13 @@ module.exports = {
     });
     return plan;
   },
+
   deleteStripePrice(priceId) {
     stripe.prices.update(priceId, {
       active: false,
     });
   },
+
   deleteStripeProduct(productId) {
     stripe.products.del(productId);
   },
@@ -153,7 +159,7 @@ module.exports = {
 
   //Subscription related
 
-  async createSubscription(customer, priceId, paymentMethodId) {
+  async createSubscription(customer, priceId, paymentMethodId, promocode) {
     const { product } = await this.findPriceByStripePriceId(priceId);
     const productData = await this.findProductByStripeProductId(product);
     const endDate = new Date();
@@ -174,6 +180,7 @@ module.exports = {
       expand: ["latest_invoice"],
       default_payment_method: paymentMethodId,
       collection_method: common.COLLECTION_METHOD.AUTOMATIC,
+      promotion_code: promocode,
     });
     return subscription;
   },
@@ -186,20 +193,25 @@ module.exports = {
       },
     });
   },
+
   async pauseSubscription(subscriptionId) {
     const subscription = await stripe.subscriptions.update(subscriptionId, {
       pause_collection: {
-        behavior: "mark_uncollectible",
+        behavior: common.COLLECTION_BEHAVIOUR.UNCOLLECTIBLE,
       },
     });
     return subscription;
   },
+
   async resumeSubscription(subscriptionId) {
     const subscription = await stripe.subscriptions.update(subscriptionId, {
       pause_collection: null,
+      // billing_cycle_anchor: "now",
+      // proration_behavior: "create_prorations",
     });
     return subscription;
   },
+
   async cancelSubscription(subscriptionId, feedback) {
     await stripe.subscriptions.cancel(subscriptionId, {
       cancellation_details: {
@@ -215,6 +227,7 @@ module.exports = {
     });
     return subscriptions.data;
   },
+
   async getSubscriptionBySubscriptionId(subscriptionId) {
     const subscriptions = await stripe.subscriptions.retrieve(subscriptionId);
     return subscriptions;
@@ -272,8 +285,70 @@ module.exports = {
   },
 
   async getPaymentIntentById(id) {
-    const paymentIntent = await stripe.paymentIntents.retrieve(id);
+    const paymentIntent = await stripe.paymentIntents.retrieve(id, {
+      expand: ["latest_charge"],
+    });
     return paymentIntent;
+  },
+
+  //Promocode related
+
+  async createCoupen(couponData) {
+    const couponObj = {
+      id: couponData.name,
+      name: couponData.name,
+      duration: couponData.durationType,
+      duration_in_months: couponData.duration_in_months,
+      currency: couponData.currency,
+    };
+    if (couponData.amount_off) {
+      couponObj.amount_off = parseFloat(couponData.amount_off * 100);
+    }
+    if (couponData.percent_off) {
+      couponObj.percent_off = parseFloat(couponData.percent_off);
+    }
+
+    const coupon = await stripe.coupons.create(couponObj);
+    return coupon;
+  },
+
+  async updateCoupon(couponId, updateObj) {
+    const updatedCoupon = await stripe.coupons.update(couponId, updateObj);
+    return updatedCoupon;
+  },
+
+  async deleteCoupon(couponId) {
+    await stripe.coupons.del(couponId);
+  },
+
+  async createPromocode(promocodeData, stripeCouponId) {
+    const promocodeObj = {
+      coupon: stripeCouponId,
+      code: promocodeData.code,
+      expires_at: promocodeData.expires_at,
+      max_redemptions: promocodeData.max_redemptions || null,
+    };
+    if (promocodeData.minimum_amount && promocodeData.minimum_amount_currency) {
+      promocodeObj.restrictions = {
+        minimum_amount: promocodeData.minimum_amount,
+        minimum_amount_currency: promocodeData.minimum_amount_currency,
+      };
+    }
+    const promocode = await stripe.promotionCodes.create(promocodeObj);
+    return promocode;
+  },
+
+  // async updatePromoCode(promoCodeId, updateObj) {
+  //   const updatedPromocode = await stripe.promotionCodes.update(promoCodeId, {
+  //     active: updateObj.active,
+  //   });
+  //   return updatedPromocode;
+  // },
+
+  async deletePromoCode(promoCodeId) {
+    await stripe.promotionCodes.update(promoCodeId, {
+      active: "false",
+    });
   },
 
   //Webhook related

--- a/utils/webhookHelper.js
+++ b/utils/webhookHelper.js
@@ -1,10 +1,17 @@
 const common = require("../constants/common");
 const paymentDb = require("../dbUtils/paymentDb");
 const userDb = require("../dbUtils/userDb");
+const helper = require("./helper");
 const stripeHelper = require("./stripeHelper");
 
 module.exports = {
   async addPaymentDataInDb(intentObj) {
+    const userFound = await userDb.findUserByStripeCustomerId(
+      intentObj.customer
+    );
+    if (!userFound) {
+      throw new Error("USER_NOT_FOUND");
+    }
     if (intentObj.invoice && intentObj.description) {
       const invoiceExist = await paymentDb.checkExistingInvoice(
         intentObj.invoice
@@ -17,14 +24,12 @@ module.exports = {
           },
           intentObj.invoice
         );
+
         return;
       }
       const invoice = await stripeHelper.getInvoiceById(intentObj.invoice);
 
-      const userFound = await userDb.findUserByStripeCustomerId(
-        intentObj.customer
-      );
-      await paymentDb.addPaymentDataInDb({
+      const newTransaction = {
         stripeCustomerId: intentObj.customer,
         userId: userFound.id,
         amount: intentObj.amount / 100,
@@ -38,7 +43,8 @@ module.exports = {
         invoiceId: intentObj.invoice,
         subscriptionId: invoice.subscription,
         paymentIntentId: intentObj.id,
-      });
+      };
+      await paymentDb.addPaymentDataInDb(newTransaction);
     }
 
     const currentStatus = await paymentDb.getPaymentStatusFromDb(


### PR DESCRIPTION
- create promocode in stripe and then add to database also with details
- create helper function for validate promocode with minimum amount and currency match or not to redeem
- also throw custom errors from or side not from stripe where possible
- create error codes for throwing errors
- create helper function for format transaction data
- change job attempt to 5 in queueHelper file
- create promocode model/table and add reference to model where needed in index.js file
- calculate manually discount in onetime payment cause stripe doesn't give such functionality